### PR TITLE
Added level picker; display up to only 5 lessons

### DIFF
--- a/DTML.EduBot/Constants/Shared.cs
+++ b/DTML.EduBot/Constants/Shared.cs
@@ -21,5 +21,11 @@ namespace DTML.EduBot.Constants
         public const string StartTheLessonPlan = "Start English Lesson Plan";
 
         public const string TooManyAttemptMessage = "Sorry, you have attempted too many times :(";
+
+        public const string LevelOne = "1";
+        public const string LevelTwo = "2";
+        public const string LevelThree = "3";
+        public const string LevelFour = "4";
+        public const string LevelFive = "5";
     }
 }

--- a/DTML.EduBot/DTML.EduBot.csproj
+++ b/DTML.EduBot/DTML.EduBot.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Constants\Shared.cs" />
     <Compile Include="Controllers\MessagesController.cs" />
     <Compile Include="Dialogs\BasicDialogModule.cs" />
+    <Compile Include="Dialogs\LevelDialog.cs" />
     <Compile Include="Dialogs\QuizDialog.cs" />
     <Compile Include="Dialogs\GreetingDialog.cs" />
     <Compile Include="Dialogs\IAmDialog.cs" />

--- a/DTML.EduBot/Dialogs/BasicDialogModule.cs
+++ b/DTML.EduBot/Dialogs/BasicDialogModule.cs
@@ -11,7 +11,7 @@
             builder.RegisterType<RootDialog>();
             builder.RegisterType<LessonPlanDialog>();
             builder.RegisterType<ChitChatDialog>();
-
+            builder.RegisterType<LevelDialog>();
         }
     }
 }

--- a/DTML.EduBot/Dialogs/LessonPlanDialog.cs
+++ b/DTML.EduBot/Dialogs/LessonPlanDialog.cs
@@ -7,11 +7,19 @@
     using Microsoft.Bot.Builder.Dialogs;
     using Microsoft.Bot.Connector;
     using DTML.EduBot.LessonPlan;
+    using DTML.EduBot.Constants;
+    using System.Collections.ObjectModel;
 
     [Serializable]
     public class LessonPlanDialog : IDialog<string>
     {
-        private const int maxRetries = 3;
+        private static readonly IEnumerable<string> LevelChoices = new ReadOnlyCollection<string>
+            (new List<String> {
+                Shared.LevelOne,
+                Shared.LevelTwo,
+                Shared.LevelThree,
+                Shared.LevelFour,
+                Shared.LevelFive});
 
         public Task StartAsync(IDialogContext context)
         {
@@ -19,9 +27,14 @@
 
             ICollection<string> lessonTitle = new List<string>();
 
+            // get up to 5 lessons
+            int i = 0;
             foreach (Lesson lesson in LessonPlanModule.LessonPlan.Lessons)
             {
+                if (i >= 5) break;
+
                 lessonTitle.Add(lesson.LessonTitle);
+                i++;
             }
 
             PromptDialog.Choice(
@@ -30,7 +43,7 @@
                 lessonTitle,
                 $"{friendlyUserName} Which lesson would you like to start?",
                 "I am sorry but I didn't understand that. I need you to select one of the options below",
-                attempts: maxRetries);
+                attempts: Shared.MaxAttempt);
 
             return Task.CompletedTask;
         }

--- a/DTML.EduBot/Dialogs/LevelDialog.cs
+++ b/DTML.EduBot/Dialogs/LevelDialog.cs
@@ -1,0 +1,61 @@
+﻿namespace DTML.EduBot.Dialogs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder.Dialogs;
+    using DTML.EduBot.Constants;
+    using System.Collections.ObjectModel;
+    using Autofac;
+
+    [Serializable]
+    public class LevelDialog : IDialog<string>
+    {
+        private static readonly IEnumerable<string> LevelChoices = new ReadOnlyCollection<string>
+            (new List<String> {
+                Shared.LevelOne,
+                Shared.LevelTwo,
+                Shared.LevelThree,
+                Shared.LevelFour,
+                Shared.LevelFive});
+
+        public Task StartAsync(IDialogContext context)
+        {
+            PromptDialog.Choice(
+                context,
+                this.AfterLevelSelected,
+                LevelChoices,
+                "Which level are you?",
+                "I am sorry but I didn't understand that. I need you to select one of the options below",
+                attempts: Shared.MaxAttempt);
+
+            return Task.CompletedTask;
+        }
+
+        private async Task AfterLevelSelected(IDialogContext context, IAwaitable<string> result)
+        {
+            try
+            {
+                var selection = await result;
+
+                // TODO: choose lesson plan based on level selection. currently just automatically navigating to
+                // the one lesson plan that we have
+                using (var scope = WebApiApplication.FindContainer().BeginLifetimeScope())
+                {
+                    context.Call(scope.Resolve<LessonPlanDialog>(), this.AfterLevelFinished);
+                }
+            }
+            catch (TooManyAttemptsException)
+            {
+                await this.StartAsync(context);
+            }
+        }
+
+        private Task AfterLevelFinished(IDialogContext context, IAwaitable<string> result)
+        {
+            context.Done(string.Empty);
+            return Task.CompletedTask;
+        }
+
+    }
+}

--- a/DTML.EduBot/Dialogs/RootDialog.cs
+++ b/DTML.EduBot/Dialogs/RootDialog.cs
@@ -162,7 +162,7 @@
                             break;
 
                         case Shared.StartTheLessonPlan:
-                            context.Call(scope.Resolve<LessonPlanDialog>(), this.AfterDialogEnded);
+                            context.Call(scope.Resolve<LevelDialog>(), this.AfterDialogEnded);
                             break;
                     }
                 }


### PR DESCRIPTION
Created a new dialog that displays five levels the user can choose from. In the future, each level will go to a different lesson plan. For now, clicking any button goes to the one lesson plan that we have.
 
Additionally limited the lesson view to show at most five lessons from the chosen lesson plan. We do not want to overwhelm the user with a long list of choices.