### PR TITLE
Remove "got it, say it again" dialog and added stars

### DIFF
--- a/DTML.EduBot/App_Start/WebApiConfig.cs
+++ b/DTML.EduBot/App_Start/WebApiConfig.cs
@@ -4,6 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using System.Web.Http.ExceptionHandling;
+using DTML.EduBot.Common;
+using System.Diagnostics;
 
 namespace DTML.EduBot
 {
@@ -32,6 +35,10 @@ namespace DTML.EduBot
                 routeTemplate: "api/{controller}/{id}",
                 defaults: new { id = RouteParameter.Optional }
             );
+
+            config.Services.Add(typeof(IExceptionLogger),
+                new TraceSourceExceptionLogger(new
+                TraceSource("MyTraceSource", SourceLevels.All)));
         }
     }
 }

--- a/DTML.EduBot/Common/TraceSourceExceptionLogger.cs
+++ b/DTML.EduBot/Common/TraceSourceExceptionLogger.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Web;
+using System.Web.Http.ExceptionHandling;
+
+namespace DTML.EduBot.Common
+{
+    public class TraceSourceExceptionLogger : ExceptionLogger
+    {
+        private readonly TraceSource _traceSource;
+
+        public TraceSourceExceptionLogger(TraceSource traceSource)
+        {
+            _traceSource = traceSource;
+        }
+
+        public override void Log(ExceptionLoggerContext context)
+        {
+            _traceSource.TraceEvent(TraceEventType.Error, 1,
+                "Unhandled exception processing {0} for {1}: {2}, w/ user ID: {3}",
+                context.Request.Method,
+                context.Request.RequestUri,
+                context.Exception,
+                context.Exception.Data["id"]);
+
+            Console.WriteLine(context.Exception.Data["id"]);
+        }
+    }
+}

--- a/DTML.EduBot/Common/TraceSourceExceptionLogger.cs
+++ b/DTML.EduBot/Common/TraceSourceExceptionLogger.cs
@@ -24,8 +24,6 @@ namespace DTML.EduBot.Common
                 context.Request.RequestUri,
                 context.Exception,
                 context.Exception.Data["id"]);
-
-            Console.WriteLine(context.Exception.Data["id"]);
         }
     }
 }

--- a/DTML.EduBot/Constants/Shared.cs
+++ b/DTML.EduBot/Constants/Shared.cs
@@ -24,6 +24,10 @@ namespace DTML.EduBot.Constants
         public const string RepeatAfterMe = "Hear and repeat the phrase below:";
         public const string CorrectAnswerMessage = "That is correct.!";
         public const string TopicCompleteMessage = "WOW! You finished the whole topic! ";
+        public const string LessonCompleteMessage = "This is the end of the current lesson. Thank you!";
+        public const string AllTopicsCompleteMessage = "You completed all the topics. Congratulations!";
+        public const string DoNotUnderstand = "I am sorry but I didn't understand that. I need you to select one of the options below";
+        public const string ReadyForQuiz = "Are you ready for the quiz?";
 
         public const string LevelOne = "1";
         public const string LevelTwo = "2";

--- a/DTML.EduBot/Constants/Shared.cs
+++ b/DTML.EduBot/Constants/Shared.cs
@@ -23,6 +23,7 @@ namespace DTML.EduBot.Constants
         public const string TooManyAttemptMessage = "Sorry, you have attempted too many times :(";
         public const string RepeatAfterMe = "Hear and repeat the phrase below:";
         public const string CorrectAnswerMessage = "That is correct.!";
+        public const string TopicCompleteMessage = "WOW! You finished the whole topic! ";
 
         public const string LevelOne = "1";
         public const string LevelTwo = "2";

--- a/DTML.EduBot/DTML.EduBot.csproj
+++ b/DTML.EduBot/DTML.EduBot.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Common\BotPersonality.cs" />
     <Compile Include="Common\ChatContext.cs" />
     <Compile Include="Common\MessageTranslator.cs" />
+    <Compile Include="Common\TraceSourceExceptionLogger.cs" />
     <Compile Include="Constants\BotEntities.cs" />
     <Compile Include="Constants\Shared.cs" />
     <Compile Include="Controllers\MessagesController.cs" />

--- a/DTML.EduBot/Dialogs/LessonDialog.cs
+++ b/DTML.EduBot/Dialogs/LessonDialog.cs
@@ -7,6 +7,7 @@
     using System.Threading.Tasks;
     using AdaptiveCards;
     using DTML.EduBot.LessonPlan;
+    using DTML.EduBot.Constants;
     using Microsoft.Bot.Builder.Dialogs;
     using Microsoft.Bot.Connector;
     using Models;
@@ -20,8 +21,8 @@
 
         private static readonly IEnumerable<string> YesNoChoices = new ReadOnlyCollection<string>
             (new List<String> {
-                Constants.Shared.Yes,
-                Constants.Shared.No });
+                Shared.Yes,
+                Shared.No });
 
         public LessonDialog(Lesson lesson)
         {
@@ -33,7 +34,7 @@
             var wasSuccess = await PostAdaptiveCard(context);
             if (!wasSuccess)
             {
-                context.Done(Constants.Shared.NoMoreLessonsMessage);
+                context.Done(Shared.NoMoreLessonsMessage);
                 return;
             }
 
@@ -152,14 +153,14 @@
                 return;
             }
 
-            await context.PostAsync(Constants.Shared.CorrectAnswerMessage);
+            await context.PostAsync(Shared.CorrectAnswerMessage);
             await this.PostAudioInstruction(context, topic);
             context.Wait(CheckAudioExercise);
         }
 
         private async Task PostAudioInstruction(IDialogContext context, Topic topic)
         {
-            await context.PostAsync(Constants.Shared.RepeatAfterMe);
+            await context.PostAsync(Shared.RepeatAfterMe);
 
             // client handling at: https://github.com/eklavyamirani/BotFramework-WebChat/commit/a0cc2cf87563414c558691583788bbd8e8c8f6a2
             await context.SayAsync(topic.CorrectAnswer, topic.CorrectAnswer, new MessageOptions
@@ -184,13 +185,13 @@
                 return;
             }
 
-            await context.PostAsync(Constants.Shared.CorrectAnswerMessage);
+            await context.PostAsync(Shared.CorrectAnswerMessage);
             await this.WrapUpCurrentTopic(context);
         }
 
         private async Task WrapUpCurrentTopic(IDialogContext context)
         {
-            string topicMessage = Constants.Shared.TopicCompleteMessage;
+            string topicMessage = Shared.TopicCompleteMessage;
 
             // display number of stars for number of topics done
             for (int i = 0; i < lesson.currentTopic + 1; i++)
@@ -202,13 +203,13 @@
             if (lesson.currentTopic >= lesson.Topics.Count - 1)
             // after finish last topic, ask if they want to take lesson's quiz
             {
-                await context.PostAsync("You completed all the topics. Congratulations!");
+                await context.PostAsync(Shared.AllTopicsCompleteMessage);
                 PromptDialog.Choice(
                     context,
                     this.AfterWrapUpCurrentLesson,
                     YesNoChoices,
-                    "Are you ready for the quiz?",
-                    "I am sorry but I didn't understand that. I need you to select one of the options below",
+                    Shared.ReadyForQuiz,
+                    Shared.DoNotUnderstand,
                     attempts: MAX_ATTEMPT);
             }
             else
@@ -220,14 +221,22 @@
 
         private async Task AfterWrapUpCurrentLesson(IDialogContext context, IAwaitable<string> result)
         {
-            var selection = await result as string;
-            if (selection.Equals(Constants.Shared.Yes, StringComparison.InvariantCultureIgnoreCase))
+            try
             {
-                context.Call(new QuizDialog(lesson.Quiz), this.AfterQuizFinished);
+                var selection = await result as string;
+                if (selection.Equals(Shared.Yes, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    context.Call(new QuizDialog(lesson.Quiz), this.AfterQuizFinished);
+                }
+                else
+                {
+                    context.Done(Shared.LessonCompleteMessage);
+                }
             }
-            else
+            catch (TooManyAttemptsException)
             {
-                context.Done("This is the end of the current lesson. Thank you!");
+                await context.PostAsync("It looks like you are not ready.");
+                context.Done(Shared.LessonCompleteMessage);
             }
         }
 
@@ -236,7 +245,7 @@
             // The current lesson finished. Plug in Analytics.
             var finalMessage = await result;
             await context.PostAsync(finalMessage);
-            context.Done("This is the end of the current lesson. Thank you!");
+            context.Done(Shared.LessonCompleteMessage);
         }
 
         private async Task<dynamic> ExtractMessageValue(IAwaitable<IMessageActivity> result)

--- a/DTML.EduBot/Dialogs/LessonPlanDialog.cs
+++ b/DTML.EduBot/Dialogs/LessonPlanDialog.cs
@@ -42,7 +42,7 @@
                 this.AfterLessonSelected,
                 lessonTitle,
                 $"{friendlyUserName} Which lesson would you like to start?",
-                "I am sorry but I didn't understand that. I need you to select one of the options below",
+                Shared.DoNotUnderstand,
                 attempts: Shared.MaxAttempt);
 
             return Task.CompletedTask;

--- a/DTML.EduBot/Dialogs/LevelDialog.cs
+++ b/DTML.EduBot/Dialogs/LevelDialog.cs
@@ -26,7 +26,7 @@
                 this.AfterLevelSelected,
                 LevelChoices,
                 "Which level are you?",
-                "I am sorry but I didn't understand that. I need you to select one of the options below",
+                Shared.DoNotUnderstand,
                 attempts: Shared.MaxAttempt);
 
             return Task.CompletedTask;

--- a/DTML.EduBot/Dialogs/RootDialog.cs
+++ b/DTML.EduBot/Dialogs/RootDialog.cs
@@ -83,7 +83,7 @@
 
                     string translatedSwitchQuestion = await MessageTranslator.TranslateTextAsync($"Do you want to switch to {detectedLanguageName}", detectedLanguageIsoCode);
 
-                    string translatedDontUnderstand = await MessageTranslator.TranslateTextAsync("I am sorry but I didn't understand that. I need you to select one of the options below", detectedLanguageIsoCode);
+                    string translatedDontUnderstand = await MessageTranslator.TranslateTextAsync(Shared.DoNotUnderstand, detectedLanguageIsoCode);
 
                     PromptDialog.Choice(
                         context,
@@ -116,7 +116,7 @@
                 this.AfterDialogChoiceSelectedAsync,
                 DialogChoices,
                 $"Hey there {userText},\n What would you like to do.",
-                "I am sorry but I didn't understand that. I need you to select one of the options below",
+                Shared.DoNotUnderstand,
                 attempts: Shared.MaxAttempt);
         }
 
@@ -135,7 +135,7 @@
 
             string translatedNotUnderstandSelection =
                 await MessageTranslator.TranslateTextAsync(
-                    "I am sorry but I didn't understand that. I need you to select one of the options below", nativeLanguageIsoCode);
+                    Shared.DoNotUnderstand, nativeLanguageIsoCode);
 
             PromptDialog.Choice(
                 context,

--- a/DTML.EduBot/LessonPlan/Topic.cs
+++ b/DTML.EduBot/LessonPlan/Topic.cs
@@ -38,13 +38,5 @@
         [DefaultValue("Good work! Here is how you say it, Repeat after me.")]
         [JsonProperty("pronounciation_phrase", DefaultValueHandling = DefaultValueHandling.Populate)]
         public string PronounciationPhrase { get; set; }
-
-        [DefaultValue("I got it")]
-        [JsonProperty("next_topic_phrase", DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string NextTopicPhrase { get; set; }
-
-        [DefaultValue("Say it again")]
-        [JsonProperty("stay_on_current_topic_phrase", DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string StayOnCurrentTopicPhrase { get; set; }
     }
 }

--- a/DTML.EduBot/LessonPlan/lesson_plan.json
+++ b/DTML.EduBot/LessonPlan/lesson_plan.json
@@ -24,9 +24,7 @@
               "correct_answer": "An APPLE",
               "correct_answer_bot_response": "Good! Now, can you type the word?",
               "wrong_answer_bot_response": "Oops, that's not right, try again",
-              "pronounciation_phrase": "Nice! Here is how you say it, Repeat after me.",
-              "next_topic_phrase": "I got it",
-              "stay_on_current_topic_phrase": "Say it again"
+              "pronounciation_phrase": "Nice! Here is how you say it, Repeat after me."
             },
             {
               "question": "Good job! Lets keep going. Can you tell me what this is?",
@@ -39,9 +37,7 @@
               "correct_answer": "THE MILK",
               "correct_answer_bot_response": "Wow good job! Type it in now",
               "wrong_answer_bot_response": "Sorry, incorrect, try again",
-              "pronounciation_phrase": "Good! Now repeat after me",
-              "next_topic_phrase": "I got it",
-              "stay_on_current_topic_phrase": "Say it again"
+              "pronounciation_phrase": "Good! Now repeat after me"
             }
           ],
           "quiz": {


### PR DESCRIPTION
After completing a topic, we had the option for the user to say "got it" or "say it again". I have removed that. Instead, the user gets a congratulatory message with a number of stars based on the number of topics they have gotten correct. The next topic then automatically starts