### PR TITLE
Fix null exception bug when user types instead of press button

### DIFF
--- a/DTML.EduBot/Dialogs/LessonDialog.cs
+++ b/DTML.EduBot/Dialogs/LessonDialog.cs
@@ -254,6 +254,10 @@
 
             if (message.Value == null)
             {
+                if (message.Text != null)
+                {
+                    return message.Text;
+                }
                 return null;
             }
 

--- a/DTML.EduBot/Models/StudentResponse.cs
+++ b/DTML.EduBot/Models/StudentResponse.cs
@@ -15,6 +15,10 @@ namespace DTML.EduBot.Models
             {
                 throw new ArgumentNullException(nameof(studentResponse));
             }
+            else if (studentResponse.Result is string)
+            {
+                return new StudentResponse(studentResponse.Result);
+            }
 
             StudentResponse answer;
 


### PR DESCRIPTION
Previously, when the user was identify what an image is in the topic, if they typed instead of pressing one of the buttons, the program would throw a NullReferenceException. I fixed this so typing behaves the same way as pressing a button - if they type text that matches the text of the correct button, they get the question right. Otherwise, it asks them to try again.