### PR TITLE
When a lesson completes, starts over from name

### DIFF
--- a/DTML.EduBot/Constants/Shared.cs
+++ b/DTML.EduBot/Constants/Shared.cs
@@ -24,7 +24,7 @@ namespace DTML.EduBot.Constants
         public const string RepeatAfterMe = "Hear and repeat the phrase below:";
         public const string CorrectAnswerMessage = "That is correct.!";
         public const string TopicCompleteMessage = "WOW! You finished the whole topic! ";
-        public const string LessonCompleteMessage = "This is the end of the current lesson. Thank you!";
+        public const string LessonCompleteMessage = "This is the end of the current lesson. What would you like to do next?";
         public const string AllTopicsCompleteMessage = "You completed all the topics. Congratulations!";
         public const string DoNotUnderstand = "I am sorry but I didn't understand that. I need you to select one of the options below";
         public const string ReadyForQuiz = "Are you ready for the quiz?";


### PR DESCRIPTION
The previous checkin already addresses this - end of lesson plan defaults back to chit chat mode. This change just makes the end of lesson message engage the user in chitchat again